### PR TITLE
Avoid saving nilTime into *.etldatetime

### DIFF
--- a/snowman.go
+++ b/snowman.go
@@ -126,6 +126,9 @@ func procwrap(result MongoEvent, waitGroup *sizedwaitgroup.SizedWaitGroup, procf
 
 // Save lastETL position in specified file
 func (f *Settings) saveposition() {
+	if f.lastETL != *new(time.Time) {
+		return
+	}
 	_ = ioutil.WriteFile(f.Trackingfile, []byte(f.lastETL.String()), 0644)
 	fmt.Println("Saving position: ", f.lastETL.String())
 }


### PR DESCRIPTION
When we are processing the last etldatetime, we error for "`nilTime`"

    *new(time.Time) # 0001-01-01 00:00:00 +0000 UTC

This was not an issue in production as we always had sample events that
it modeled, but when we want to test specific parts of
`analytics_modeling` it results in failure.